### PR TITLE
Rlt edit tags

### DIFF
--- a/src/components/ApplicationViews.js
+++ b/src/components/ApplicationViews.js
@@ -12,6 +12,7 @@ import { MyPosts } from "./posts/MyPosts.js"
 import { PostsByUser } from "./posts/PostsByUser.js"
 import { SinglePost } from "./posts/SinglePost.js"
 import { getCurrentUser } from "./users/UserManager";
+import { NewTagForm } from "./tags/CreateTagForm.js"
 
 export const ApplicationViews = () => {
   //state to refresh state when new object is submitted
@@ -49,6 +50,9 @@ export const ApplicationViews = () => {
       </Route>
       <Route exact path="/editPost/:postId(\d+)">
         <CreatePosts currentUser={currentUser} editing={true} />
+      </Route>
+      <Route exact path="/editTag/:tagId(\d+)">
+        <NewTagForm currentUser={currentUser} editing={true} />
       </Route>
       <Route exact path="/posts/single/:postId(\d+)">
         <SinglePost />

--- a/src/components/ApplicationViews.js
+++ b/src/components/ApplicationViews.js
@@ -13,6 +13,7 @@ import { PostsByUser } from "./posts/PostsByUser.js"
 import { SinglePost } from "./posts/SinglePost.js"
 import { getCurrentUser } from "./users/UserManager";
 import { NewTagForm } from "./tags/CreateTagForm.js"
+import { EditTag } from "./tags/EditTag.js"
 
 export const ApplicationViews = () => {
   //state to refresh state when new object is submitted
@@ -62,7 +63,7 @@ export const ApplicationViews = () => {
         <CreatePosts currentUser={currentUser} editing={true} />
       </Route>
       <Route exact path="/editTag/:tagId(\d+)">
-        <NewTagForm currentUser={currentUser} editing={true} />
+        <EditTag currentUser={currentUser} refreshState={refreshState} setRefreshState={setRefreshState}/>
       </Route>
       <Route exact path="/posts/single/:postId(\d+)">
         <SinglePost />

--- a/src/components/buttonControls/ButtonControls.js
+++ b/src/components/buttonControls/ButtonControls.js
@@ -73,7 +73,7 @@ export const ButtonControls = ({ isPost=undefined, id=undefined, commentId=undef
       if(isPost) {
         history.push(`/editPost/${id}`)
       } else if(isTags) {
-          history.push('/tags')
+          history.push(`/editTag/${id}`)
       } else {
         window.alert("Cannot edit comments")
       }

--- a/src/components/tags/AllTags.js
+++ b/src/components/tags/AllTags.js
@@ -21,6 +21,7 @@ export const AllTags = ({refreshState, setRefreshState, tags, currentUser}) => {
                             <ButtonControls 
                                 isTags={true} 
                                 id={tag.id} 
+                                tags={tags}
                                 setRefreshState={setRefreshState} />
                             </div>
                         : null

--- a/src/components/tags/CreateTagForm.js
+++ b/src/components/tags/CreateTagForm.js
@@ -2,10 +2,12 @@ import React, { useState } from "react";
 import { submitNewTag } from "./TagManager";
 
 
-export const NewTagForm = ({ setRefreshState }) => {
+export const NewTagForm = ({ setRefreshState, editing }) => {
     const [newTagForm, setNewTagForm] = useState(false)
     const [form, updateForm] = useState({ label: "" })
-
+    if (editing) {
+        setNewTagForm(true)
+    }
 
 
     return (

--- a/src/components/tags/CreateTagForm.js
+++ b/src/components/tags/CreateTagForm.js
@@ -2,12 +2,10 @@ import React, { useState } from "react";
 import { submitNewTag } from "./TagManager";
 
 
-export const NewTagForm = ({ setRefreshState, editing }) => {
+export const NewTagForm = ({ setRefreshState }) => {
     const [newTagForm, setNewTagForm] = useState(false)
     const [form, updateForm] = useState({ label: "" })
-    if (editing) {
-        setNewTagForm(true)
-    }
+    
 
 
     return (

--- a/src/components/tags/EditTag.js
+++ b/src/components/tags/EditTag.js
@@ -1,0 +1,55 @@
+import React, { useEffect, useState } from "react";
+import { useHistory, useParams } from "react-router-dom";
+import { getSingleTag, sendTagEdit, submitNewTag } from "./TagManager";
+
+
+export const EditTag = ({setRefreshState}) => {
+
+    const [tag, setTag] = useState({})
+    const tagId = useParams()
+    const history = useHistory()
+    useEffect(() => {
+        getSingleTag(tagId.tagId)
+        .then(data => setTag(data))
+    },
+    [tagId])
+
+    return (
+        <>
+            <fieldset>
+                <div className="form-group">
+                    <label htmlFor="tag">Edit tag</label>
+                    <input
+                        required autoFocus
+                        type="text" id="tag"
+                        className="form-control"
+                        value={tag.label}
+                        onChange={
+                            (e) => {
+                                const copy = { ...tag }
+                                copy.label = e.target.value
+                                setTag(copy)
+                            }
+                        }
+                    />
+                    <div className="submitButtonCreateNewTagForm">
+                        {/* when clicked will invoke the submit new tag function */}
+                        <button onClick={(e) => {
+                            e.preventDefault()
+                            sendTagEdit(tag)
+                            setRefreshState(true)
+                            history.push('/tags')
+                        }} className="submit-button">
+                            Submit
+                        </button>
+                        <button onClick={()=>history.push('/tags')}>
+                            Cancel
+                        </button>
+                    </div>
+                </div>
+            </fieldset>
+
+        </>
+    )
+
+}

--- a/src/components/tags/TagManager.js
+++ b/src/components/tags/TagManager.js
@@ -9,6 +9,26 @@ export const getAllTags = () => {
   })
       .then(response => response.json())
 }
+export const getSingleTag = (id) => {
+  return fetch(`${Settings.API}/tags/${id}`, {
+      headers:{
+          "Authorization": `Token ${localStorage.getItem("token")}`
+      }
+  })
+      .then(response => response.json())
+}
+export const sendTagEdit = (tag) => {
+  const id = tag.id
+  return fetch(`${Settings.API}/tags/${id}`, {
+      method: "PUT",
+      headers:{
+          "Content-Type": "application/json",
+          "Authorization": `Token ${localStorage.getItem("token")}`
+      },
+      body: JSON.stringify(tag)
+  })
+}
+
 
 export const submitNewTag = (tag) => {
   return fetch(`${Settings.API}/tags`, {


### PR DESCRIPTION
tags can now be edited by admins



Fixes # 19

## Type of change

Please delete options that are not relevant.


- New feature (non-breaking change which adds functionality)


- [ ] pull code, start server
- [ ] click on tags manager
- [ ] click on edit tag
- [ ] edit tag and send in edit
- [ ] user should be pushed back to tags list with updated tag
- [ ] if user pushed cancel in tag edit, they should be pushed back to the list as well

