### PR TITLE
Jeh view users posts

### DIFF
--- a/src/components/users/User.js
+++ b/src/components/users/User.js
@@ -34,10 +34,8 @@ export const User = ({ listView, user, refreshState, setUsers, setRefreshState }
 
     useEffect(
         () => {
-            if (viewUser) {
-                getUserPosts(userId)
-                    .then(data => setUserPosts(data))
-                let count = userPosts.length
+            if(viewUser) {
+                let count = viewUser.user?.posts?.length
                 setPostCount(count)
             }
         }, [viewUser]

--- a/src/components/users/User.js
+++ b/src/components/users/User.js
@@ -32,14 +32,14 @@ export const User = ({ listView, user, refreshState, setUsers, setRefreshState }
         }, [userId, listView]
     )
 
-    useEffect(
-        () => {
-            if(viewUser) {
-                let count = viewUser.user?.posts?.length
-                setPostCount(count)
-            }
-        }, [viewUser]
-    )
+    // useEffect(
+    //     () => {
+    //         if(viewUser) {
+    //             let count = viewUser.user?.posts?.length
+    //             setPostCount(count)
+    //         }
+    //     }, [viewUser]
+    //)
 
     // does subscribe button need an onclick?
     // yes
@@ -78,7 +78,7 @@ export const User = ({ listView, user, refreshState, setUsers, setRefreshState }
                         <td>Profile Type: {viewUser.user.is_staff ? "Admin" : "Author"}</td>
                         <td>
                             <Link to={`/posts/user/${viewUser.user.id}`}>
-                                See Articles - Count: {postCount}
+                                See Articles - Count: {viewUser.post_count}
                             </Link>
                         </td>
                         <td>


### PR DESCRIPTION
# Description

A user can now view the user's post count when going to the users page and clicking on a users details.

Fixes # 35

## Type of change

Please delete options that are not relevant.

- New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Pull code for client and server - make sure author view and user.js have code changes.
- [ ] Test in client by going to Users - click users profile details and check for post count to show the right number of posts for that user.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings